### PR TITLE
fix: suggestions not rendering on button click in search panel section on home page

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -228,7 +228,8 @@
   });
 
   document.querySelectorAll('[data-search-preset]').forEach((chip) => {
-    chip.addEventListener('click', () => {
+    chip.addEventListener('click', (event) => {
+      event.stopPropagation();
       const targetSelector = chip.dataset.targetInput;
       const target = document.querySelector(targetSelector);
       if (!target) return;


### PR DESCRIPTION
### Issue
Suggestions were not rendering when clicking filter buttons in the search panel.

https://github.com/user-attachments/assets/5f7da448-0490-494e-9bae-a78dff7aff8c


### Fix

https://github.com/user-attachments/assets/a4191203-8704-48ae-aa28-a20464fb6633


I stopped event propogation when we are clicking on any chip/wire filter button on home page which helps in  showing suggestions list

### Result
Suggestions now display correctly when interacting with filter buttons.